### PR TITLE
Implemented sha3 python module and verified against test vectors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 *.out
 *.log
 *.bin
+venv/
+__pycache__/

--- a/COPILOT.md
+++ b/COPILOT.md
@@ -1,0 +1,59 @@
+### SHA-3 Algorithm Summary
+
+**Overview**
+SHA-3 (Secure Hash Algorithm 3) is defined in the NIST FIPS 202 standard and is based on the Keccak cryptographic family. Unlike its predecessors (SHA-1 and SHA-2), which use the Merkle-Damgård construction, SHA-3 utilizes the **sponge construction**. Ideally suited for an AI agent's processing logic, the algorithm operates on a fixed-width state through a sequence of absorbing and squeezing phases.
+
+#### 1. Algorithmic Steps
+
+**Step 1: Initialization**
+The internal state, denoted as $S$, is initialized to a grid of zeros. The state width ($b$) is fixed at 1600 bits for the standard SHA-3 instances. This state is conceptually organized as a $5 \times 5 \times 64$ bit 3D array (5 rows, 5 columns, 64-bit lanes).
+
+**Step 2: Padding and Domain Separation**
+The input message $M$ is padded to ensures its length is a multiple of the rate $r$.
+*   **Domain Suffix:** A specific suffix is appended to the message to distinguish between functions. For SHA-3 hash functions, the suffix is `01`. For SHAKE (XOFs), the suffix is `1111`.
+*   **Padding Rule:** The padding pattern **pad10*1** is applied. A '1' bit is appended, followed by a minimum number of '0' bits, and a final '1' bit is added at the end of the block.
+
+**Step 3: Absorbing Phase**
+The padded message is split into blocks ($P_i$), each having a length of $r$ bits.
+*   The block is XORed with the first $r$ bits of the state (the rate part). The remaining $c$ bits (capacity) are not touched.
+*   The state undergoes the **Keccak-f** permutation function (detailed below).
+*   This cycle repeats until all input blocks are processed.
+
+**Step 4: The Keccak-f Permutation**
+The permutation consists of **24 rounds**. Each round applies five mapping steps in sequence to the state matrix $A$:
+1.  **Theta ($\theta$):** Provides linear diffusion by computing the parity of columns and XORing the result into nearby columns.
+2.  **Rho ($\rho$):** Provides inter-slice diffusion via lane-wise bit rotations using fixed offsets.
+3.  **Pi ($\pi$):** Permutes the positions of the lanes within the state matrix.
+4.  **Chi ($\chi$):** The only non-linear operation. It updates bits using row-wise XOR, NOT, and AND operations (conceptually an S-box).
+5.  **Iota ($\iota$):** Breaks symmetry by XORing a round-dependent constant into the first lane of the state.
+
+**Step 5: Squeezing Phase**
+*   The first $r$ bits of the state are extracted as output.
+*   If the required output length ($d$) exceeds $r$, the permutation function Keccak-f is applied again to the state, and additional bits are extracted.
+*   The final output is truncated to the desired length $d$.
+
+---
+
+#### 2. Algorithm Parameters
+
+The SHA-3 family is defined by the state width $b = 1600$. The relationship between the Rate ($r$) and Capacity ($c$) is defined as $r + c = 1600$. Higher capacity yields higher security but lower throughput.
+
+**Global Constants**
+*   **State Width ($b$):** 1600 bits.
+*   **Word Size ($w$):** 64 bits.
+*   **Number of Rounds ($n_r$):** 24.
+*   **Padding Type:** pad10*1.
+
+**Instance-Specific Parameters**
+
+| Function | Output ($d$) | Rate ($r$) | Capacity ($c$) | Domain Suffix | Byte-Aligned Suffix (Hex)* | Collision Resistance (Bits) |
+| :--- | :--- | :--- | :--- | :--- | :--- | :--- |
+| **SHA3-224** | 224 bits | 1152 | 448 | `01` | `0x06` | 112 |
+| **SHA3-256** | 256 bits | 1088 | 512 | `01` | `0x06` | 128 |
+| **SHA3-384** | 384 bits | 832 | 768 | `01` | `0x06` | 192 |
+| **SHA3-512** | 512 bits | 576 | 1024 | `01` | `0x06` | 256 |
+| **SHAKE128** | Arbitrary | 1344 | 256 | `1111` | `0x1F` | min(d/2, 128) |
+| **SHAKE256** | Arbitrary | 1088 | 512 | `1111` | `0x1F` | min(d/2, 256) |
+
+*Table Sources:*
+*\*Note: The byte-aligned suffix represents the domain bits plus the first padding bit when the message is byte-aligned.*

--- a/examples/sha-3-python/sha3-tests.py
+++ b/examples/sha-3-python/sha3-tests.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+"""
+Test SHA3_Instrumented implementation against official test vectors and Python's hashlib.
+Test vectors from: https://www.di-mgt.com.au/sha_testvectors.html
+Copyright (C) 2012-2022 DI Management Services Pty Limited
+"""
+
+import unittest
+import hashlib
+from sha3 import SHA3_Instrumented
+
+
+class TestSHA3_256(unittest.TestCase):
+    """Test SHA3-256 implementation against known test vectors."""
+    
+    def test_abc(self):
+        """Test 'abc' - the bit string (0x)616263 of length 24 bits"""
+        message = b"abc"
+        expected = "3a985da74fe225b2045c172d6bd390bd855f086e3e9d525b46bfe24511431532"
+        
+        sha3 = SHA3_Instrumented(output_bits=256)
+        result = sha3.hash(message)
+        
+        self.assertEqual(result.hex(), expected)
+        
+        # Also verify against hashlib
+        sha3_hashlib = hashlib.sha3_256()
+        sha3_hashlib.update(message)
+        self.assertEqual(result, sha3_hashlib.digest())
+    
+    def test_empty_string(self):
+        """Test empty string - a bit string of length 0"""
+        message = b""
+        expected = "a7ffc6f8bf1ed76651c14756a061d662f580ff4de43b49fa82d80a4b80f8434a"
+        
+        sha3 = SHA3_Instrumented(output_bits=256)
+        result = sha3.hash(message)
+        
+        self.assertEqual(result.hex(), expected)
+        
+        # Also verify against hashlib
+        sha3_hashlib = hashlib.sha3_256()
+        sha3_hashlib.update(message)
+        self.assertEqual(result, sha3_hashlib.digest())
+    
+    def test_448_bits(self):
+        """Test message of length 448 bits"""
+        message = b"abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq"
+        expected = "41c0dba2a9d6240849100376a8235e2c82e1b9998a999e21db32dd97496d3376"
+        
+        sha3 = SHA3_Instrumented(output_bits=256)
+        result = sha3.hash(message)
+        
+        self.assertEqual(result.hex(), expected)
+        
+        # Also verify against hashlib
+        sha3_hashlib = hashlib.sha3_256()
+        sha3_hashlib.update(message)
+        self.assertEqual(result, sha3_hashlib.digest())
+    
+    def test_896_bits(self):
+        """Test message of length 896 bits"""
+        message = b"abcdefghbcdefghicdefghijdefghijkefghijklfghijklmghijklmnhijklmnoijklmnopjklmnopqklmnopqrlmnopqrsmnopqrstnopqrstu"
+        expected = "916f6061fe879741ca6469b43971dfdb28b1a32dc36cb3254e812be27aad1d18"
+        
+        sha3 = SHA3_Instrumented(output_bits=256)
+        result = sha3.hash(message)
+        
+        self.assertEqual(result.hex(), expected)
+        
+        # Also verify against hashlib
+        sha3_hashlib = hashlib.sha3_256()
+        sha3_hashlib.update(message)
+        self.assertEqual(result, sha3_hashlib.digest())
+    
+    def test_one_million_a(self):
+        """Test one million (1,000,000) repetitions of 'a'"""
+        message = b"a" * 1000000
+        expected = "5c8875ae474a3634ba4fd55ec85bffd661f32aca75c6d699d0cdcb6c115891c1"
+        
+        sha3 = SHA3_Instrumented(output_bits=256)
+        result = sha3.hash(message)
+        
+        self.assertEqual(result.hex(), expected)
+        
+        # Also verify against hashlib
+        sha3_hashlib = hashlib.sha3_256()
+        sha3_hashlib.update(message)
+        self.assertEqual(result, sha3_hashlib.digest())
+
+
+class TestSHA3_224(unittest.TestCase):
+    """Test SHA3-224 implementation."""
+    
+    def test_abc(self):
+        """Test 'abc' with SHA3-224"""
+        message = b"abc"
+        expected = "e642824c3f8cf24ad09234ee7d3c766fc9a3a5168d0c94ad73b46fdf"
+        
+        sha3 = SHA3_Instrumented(output_bits=224)
+        result = sha3.hash(message)
+        
+        self.assertEqual(result.hex(), expected)
+        
+        # Also verify against hashlib
+        sha3_hashlib = hashlib.sha3_224()
+        sha3_hashlib.update(message)
+        self.assertEqual(result, sha3_hashlib.digest())
+    
+    def test_empty_string(self):
+        """Test empty string with SHA3-224"""
+        message = b""
+        expected = "6b4e03423667dbb73b6e15454f0eb1abd4597f9a1b078e3f5b5a6bc7"
+        
+        sha3 = SHA3_Instrumented(output_bits=224)
+        result = sha3.hash(message)
+        
+        self.assertEqual(result.hex(), expected)
+        
+        # Also verify against hashlib
+        sha3_hashlib = hashlib.sha3_224()
+        sha3_hashlib.update(message)
+        self.assertEqual(result, sha3_hashlib.digest())
+
+
+class TestSHA3_384(unittest.TestCase):
+    """Test SHA3-384 implementation."""
+    
+    def test_abc(self):
+        """Test 'abc' with SHA3-384"""
+        message = b"abc"
+        expected = "ec01498288516fc926459f58e2c6ad8df9b473cb0fc08c2596da7cf0e49be4b298d88cea927ac7f539f1edf228376d25"
+        
+        sha3 = SHA3_Instrumented(output_bits=384)
+        result = sha3.hash(message)
+        
+        self.assertEqual(result.hex(), expected)
+        
+        # Also verify against hashlib
+        sha3_hashlib = hashlib.sha3_384()
+        sha3_hashlib.update(message)
+        self.assertEqual(result, sha3_hashlib.digest())
+    
+    def test_empty_string(self):
+        """Test empty string with SHA3-384"""
+        message = b""
+        expected = "0c63a75b845e4f7d01107d852e4c2485c51a50aaaa94fc61995e71bbee983a2ac3713831264adb47fb6bd1e058d5f004"
+        
+        sha3 = SHA3_Instrumented(output_bits=384)
+        result = sha3.hash(message)
+        
+        self.assertEqual(result.hex(), expected)
+        
+        # Also verify against hashlib
+        sha3_hashlib = hashlib.sha3_384()
+        sha3_hashlib.update(message)
+        self.assertEqual(result, sha3_hashlib.digest())
+
+
+class TestSHA3_512(unittest.TestCase):
+    """Test SHA3-512 implementation."""
+    
+    def test_abc(self):
+        """Test 'abc' with SHA3-512"""
+        message = b"abc"
+        expected = "b751850b1a57168a5693cd924b6b096e08f621827444f70d884f5d0240d2712e10e116e9192af3c91a7ec57647e3934057340b4cf408d5a56592f8274eec53f0"
+        
+        sha3 = SHA3_Instrumented(output_bits=512)
+        result = sha3.hash(message)
+        
+        self.assertEqual(result.hex(), expected)
+        
+        # Also verify against hashlib
+        sha3_hashlib = hashlib.sha3_512()
+        sha3_hashlib.update(message)
+        self.assertEqual(result, sha3_hashlib.digest())
+    
+    def test_empty_string(self):
+        """Test empty string with SHA3-512"""
+        message = b""
+        expected = "a69f73cca23a9ac5c8b567dc185a756e97c982164fe25859e0d1dcc1475c80a615b2123af1f5f94c11e3e9402c3ac558f500199d95b6d3e301758586281dcd26"
+        
+        sha3 = SHA3_Instrumented(output_bits=512)
+        result = sha3.hash(message)
+        
+        self.assertEqual(result.hex(), expected)
+        
+        # Also verify against hashlib
+        sha3_hashlib = hashlib.sha3_512()
+        sha3_hashlib.update(message)
+        self.assertEqual(result, sha3_hashlib.digest())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/examples/sha-3-python/sha3.py
+++ b/examples/sha-3-python/sha3.py
@@ -1,0 +1,255 @@
+"""
+SHA-3 (Keccak) - Instrumented Implementation for Hardware Validation
+======================================================================
+A high-granularity SHA-3 implementation designed specifically for FPGA hardware validation.
+This module captures intermediate state snapshots after each transformation step in the 
+Keccak-f[1600] permutation, enabling verification of hardware module outputs.
+
+Features:
+---------
+- Full SHA-3 implementation supporting all variants (SHA3-224, SHA3-256, SHA3-384, SHA3-512)
+- Detailed state logging after each step: theta (θ), rho (ρ), pi (π), chi (χ), iota (ι)
+- Snapshot capture at absorb, padding, and squeeze phases
+- Verified against official NIST test vectors and Python hashlib
+
+
+Note:
+-----
+This implementation prioritizes clarity and instrumentation over performance.
+It is intended for generating test vectors and validating hardware implementations,
+not for production hashing.
+
+Directly based off of the Keccak reference implementation.
+Source: https://github.com/XKCP/XKCP/blob/master/Standalone/CompactFIPS202/Python/CompactFIPS202.py#L11
+"""
+
+
+class SHA3_Instrumented: 
+    def __init__(self, output_bits=256): 
+        if output_bits not in [224, 256, 384, 512]:
+            raise ValueError("Output bits must be one of: 224, 256, 384, 512")
+        
+        self.output_bits = output_bits            # Output size in bits (224, 256, 384, or 512)
+        self.lanes = [[0] * 5 for _ in range(5)]  # 5x5 array of 64-bit lanes (i.e. A state matrix)
+        self.snapshots = []                       # List to store intermediate states
+
+
+    def log_state(self, step_name, round_num = None): 
+        """Log the current state for hardware validation."""
+        snapshot = {
+            'step': step_name,
+            'round': round_num,
+            'state': [row[:] for row in self.lanes]  # Deep copy of state
+        }
+        self.snapshots.append(snapshot)
+
+    @staticmethod
+    def __ROL64(a, n):
+        return ((a >> (64-(n%64))) + (a << (n%64))) % (1 << 64)
+
+
+    def keccak_round(self, round_index): 
+        """Execute one round of Keccak-f permutation."""
+        self.log_state('round_start', round_index)
+        self.theta()
+        self.log_state('after_theta', round_index)
+        self.rho_pi()
+        self.log_state('after_rho_pi', round_index)
+        self.chi()
+        self.log_state('after_chi', round_index)
+        self.iota(round_index)
+        self.log_state('after_iota', round_index)
+
+    def keccak_f(self, rate, capacity, inputBytes, delimitedSuffix, outputByteLen):
+        """Keccak sponge function."""
+        if(rate + capacity != 1600):
+            raise ValueError("Rate and Capacity must sum to 1600 bits.")
+        
+        self.lanes = [[0] * 5 for _ in range(5)]  # reset state for multiple calls
+        self.snapshots = []  # Reset snapshots
+        self.log_state('initial_state', None)
+        
+        rateInBytes = rate // 8
+        
+        # Absorb phase
+        self.absorb(inputBytes, rateInBytes, delimitedSuffix)
+        
+        # Squeeze phase
+        return self.squeeze(outputByteLen, rateInBytes)
+
+
+
+    def absorb(self, inputBytes, rateInBytes, delimitedSuffix):
+        """Absorb phase: XOR input into state and apply permutation."""
+        inputOffset = 0
+        blockSize = 0
+        blockNum = 0
+        
+        # === Absorb all the input blocks ===
+        while inputOffset < len(inputBytes):
+            blockSize = min(len(inputBytes) - inputOffset, rateInBytes)
+            self.log_state(f'absorb_block_{blockNum}_start', None)
+            
+            # XOR the block into state
+            block = inputBytes[inputOffset:inputOffset + blockSize]
+            self.xor_block_into_state(block)
+            
+            self.log_state(f'absorb_block_{blockNum}_after_xor', None)
+            
+            inputOffset += blockSize
+            
+            # Only apply permutation if we filled a complete block
+            if blockSize == rateInBytes:
+                for round_index in range(24):
+                    self.keccak_round(round_index)
+                self.log_state(f'absorb_block_{blockNum}_after_permutation', None)
+                blockSize = 0
+            
+            blockNum += 1
+        
+        # === Do the padding and switch to the squeezing phase ===
+        self.log_state('before_padding', None)
+        self.apply_padding(blockSize, rateInBytes, delimitedSuffix)
+        self.log_state('after_padding', None)
+        
+        # Apply final permutation
+        for round_index in range(24):
+            self.keccak_round(round_index)
+        self.log_state('after_final_permutation', None)
+    
+    def xor_block_into_state(self, block):
+        """XOR a block of bytes into the state array."""
+        for i in range(len(block)):
+            # Convert byte position to lane coordinates
+            lane_index = i // 8  # Each lane is 8 bytes
+            byte_in_lane = i % 8
+            
+            # Map linear index to (x, y) coordinates
+            x = lane_index % 5
+            y = lane_index // 5
+            
+            # XOR byte into the appropriate position in the lane
+            self.lanes[x][y] ^= block[i] << (8 * byte_in_lane)
+
+    def apply_padding(self, blockSize, rateInBytes, delimitedSuffix):
+        """Apply SHA-3 padding (10*1 pattern) to the state."""
+        # XOR delimited suffix at the position after the last absorbed byte
+        self.xor_byte_into_state(blockSize, delimitedSuffix)
+        
+        # Special case: if delimitedSuffix has MSB set and blockSize is at the last position
+        if ((delimitedSuffix & 0x80) != 0) and (blockSize == (rateInBytes - 1)):
+            for round_index in range(24):
+                self.keccak_round(round_index)
+            self.log_state('padding_special_permutation', None)
+        
+        # XOR 0x80 at the last position of the rate
+        self.xor_byte_into_state(rateInBytes - 1, 0x80)
+    
+    def xor_byte_into_state(self, position, byte_value):
+        """XOR a single byte into the state at the given position."""
+        lane_index = position // 8
+        byte_in_lane = position % 8
+        
+        x = lane_index % 5
+        y = lane_index // 5
+        
+        self.lanes[x][y] ^= byte_value << (8 * byte_in_lane)
+
+    def squeeze(self, outputByteLen, rateInBytes):
+        """Squeeze phase: Extract output bytes from state."""
+        output = bytearray()
+        
+        while len(output) < outputByteLen:
+            self.log_state(f'squeeze_block_{len(output)//rateInBytes}', None)
+            
+            # Extract bytes from state
+            block = self.extract_bytes_from_state(rateInBytes)
+            output.extend(block)
+            
+            # If we need more output, apply permutation
+            if len(output) < outputByteLen:
+                for round_index in range(24):
+                    self.keccak_round(round_index)
+        
+        return bytes(output[:outputByteLen])
+    
+    def extract_bytes_from_state(self, numBytes):
+        """Extract bytes from the state array."""
+        output = bytearray()
+        
+        for i in range(numBytes):
+            # Convert byte position to lane coordinates
+            lane_index = i // 8
+            byte_in_lane = i % 8
+            
+            # Map linear index to (x, y) coordinates
+            x = lane_index % 5
+            y = lane_index // 5
+            
+            # Extract byte from the lane
+            byte_val = (self.lanes[x][y] >> (8 * byte_in_lane)) & 0xFF
+            output.append(byte_val)
+        
+        return bytes(output)
+
+    def hash(self, data):
+        """Compute SHA-3 hash of the input data."""
+        # SHA-3 uses different parameters based on output size:
+        # SHA3-224: rate=1152, capacity=448, output=224 bits (28 bytes)
+        # SHA3-256: rate=1088, capacity=512, output=256 bits (32 bytes)
+        # SHA3-384: rate=832,  capacity=768, output=384 bits (48 bytes)
+        # SHA3-512: rate=576,  capacity=1024, output=512 bits (64 bytes)
+        
+        output_bytes = self.output_bits // 8
+        capacity = output_bytes * 2 * 8  # capacity = 2 * output_bits
+        rate = 1600 - capacity
+        
+        # SHA-3 uses 0x06 as the delimited suffix
+        delimitedSuffix = 0x06
+        
+        return self.keccak_f(rate, capacity, data, delimitedSuffix, output_bytes)
+
+    # Theta θ Step Mapping
+    def theta(self):
+        """Theta step: XOR each bit with parity of two columns."""
+        C = [0] * 5
+        D = [0] * 5
+
+        # Calculate the parity of each column
+        C = [self.lanes[x][0] ^ self.lanes[x][1] ^ self.lanes[x][2] ^ self.lanes[x][3] ^ self.lanes[x][4] for x in range(5)]
+        # Calculate the D values
+        D = [C[(x - 1) % 5] ^ self.__ROL64(C[(x + 1) % 5], 1) for x in range(5)]
+        self.lanes = [[self.lanes[x][y] ^ D[x] for y in range(5)] for x in range(5)]
+       
+
+    # ρ and π Steps Mapping
+    def rho_pi(self):
+        (x, y) = (1, 0)
+        current = self.lanes[x][y]
+        for t in range(24):
+            (x, y) = (y, (2 * x + 3 * y) % 5)
+            (current, self.lanes[x][y]) = (self.lanes[x][y], self.__ROL64(current, ((t + 1) * (t + 2) // 2)))
+
+    # Chi χ Step Mapping
+    def chi(self):
+        """Chi step: Non-linear mixing of bits within each row."""
+        for y in range(5):
+            T = [self.lanes[x][y] for x in range(5)]
+            for x in range(5):
+                self.lanes[x][y] = T[x] ^((~T[(x+1)%5]) & T[(x+2)%5])
+        
+    # Iota ι Step Mapping
+    def iota(self, round_index):
+        """Iota step: Add round constant to state."""
+        # Compute round constant using LFSR
+        R = 1
+        for i in range(round_index + 1):
+            round_constant = 0
+            for j in range(7):
+                R = ((R << 1) ^ ((R >> 7) * 0x71)) % 256
+                if (R & 2):
+                    round_constant ^= (1 << ((1 << j) - 1))
+            if i == round_index:
+                self.lanes[0][0] ^= round_constant
+        
+


### PR DESCRIPTION
@tnl3pdx I implemented a python module for providing very granular operations of each step in the sha3 algorithm. I figured this will be useful and will later be used as a utility function to automate the generation of test vectors for individual hardware modules. 

## Key Features
- Captures state snapshots after each Keccak-f transformation (θ, ρ, π, χ, ι)
- Supports all SHA-3 variants (224/256/384/512-bit)
- Verified against official NIST test vectors and Python hashlib
- 11 passing unit tests 