### PR TITLE
feat(rtl): add sha-3 round constant lookup table

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,7 @@
 *.out
 *.log
 *.bin
+.local
+build/
 venv/
 __pycache__/

--- a/BUILD.md
+++ b/BUILD.md
@@ -1,0 +1,93 @@
+# Build Instructions
+
+## Prerequisites
+
+- CMake 3.10 or higher
+- Verilator (latest version recommended)
+- C++ compiler with C++11 support
+
+## Building and Running Tests
+
+### First-time setup:
+
+```bash
+# Create build directory
+mkdir build
+cd build
+
+# Configure the project
+cmake ..
+
+# Build all tests
+make
+
+# Run all tests
+ctest
+
+# Or run with verbose output
+ctest --verbose
+```
+
+### Running individual tests:
+
+```bash
+# From the build directory
+./tests/tb_rconst_lut
+
+# Or using ctest
+ctest -R tb_rconst_lut --verbose
+```
+
+### Incremental builds:
+
+After making changes to RTL or testbench code:
+
+```bash
+cd build
+make          # Rebuild only what changed
+ctest         # Run all tests
+```
+
+## Adding New Tests
+
+To add a new test, simply add one line to `tests/CMakeLists.txt`:
+
+```cmake
+add_verilator_test(tb_my_module my_module ${RTL_DIR}/my_module.sv)
+```
+
+Where:
+- `tb_my_module` is the name of your testbench C++ file (without .cpp extension)
+- `my_module` is the name of the top-level SystemVerilog module
+- `${RTL_DIR}/my_module.sv` is the path to your SystemVerilog file(s)
+
+Multiple RTL files can be specified:
+```cmake
+add_verilator_test(tb_complex complex_top 
+    ${RTL_DIR}/module1.sv 
+    ${RTL_DIR}/module2.sv
+    ${RTL_DIR}/module3.sv)
+```
+
+## Clean Build
+
+```bash
+rm -rf build
+mkdir build
+cd build
+cmake ..
+make
+```
+
+## CMake Options
+
+```bash
+# Build with debug symbols
+cmake -DCMAKE_BUILD_TYPE=Debug ..
+
+# Build with optimizations
+cmake -DCMAKE_BUILD_TYPE=Release ..
+
+# Specify Verilator location if not in PATH
+cmake -DVERILATOR_ROOT=/path/to/verilator ..
+```

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,24 @@
+cmake_minimum_required(VERSION 3.10)
+project(fpga-sha3-hardware-impl LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+# Find Verilator
+find_package(verilator HINTS $ENV{VERILATOR_ROOT})
+
+if (NOT verilator_FOUND)
+  message(FATAL_ERROR "Verilator not found. Please install Verilator or set VERILATOR_ROOT environment variable")
+endif()
+
+message(STATUS "Found Verilator: ${verilator_DIR}")
+
+# Set RTL directory path for use in subdirectories
+set(RTL_DIR ${CMAKE_SOURCE_DIR}/rtl)
+
+# Enable CTest
+enable_testing()
+
+# Add tests subdirectory
+add_subdirectory(tests)

--- a/rtl/rconst_lut.sv
+++ b/rtl/rconst_lut.sv
@@ -1,0 +1,80 @@
+/*
+ * Module: sha3_rc_lut
+ * -------------------
+ * Implementation of SHA-3 (Keccak) Round Constants using an area-optimized 
+ * 7-bit Look-Up Table (LUT).
+ *
+ * Optimization Logic:
+ * Per the Keccak specification (and highlighted by Chemejon's "SHA-3 Explained"), 
+ * only 7 specific bit positions in the 64-bit Round Constant (RC) are ever 
+ * non-zero. These positions follow the sequence 2^j - 1 [ for j=0 to 6]:
+ * j=0: bit 0
+ * j=1: bit 1
+ * j=2: bit 3
+ * j=3: bit 7
+ * j=4: bit 15
+ * j=5: bit 31
+ * j=6: bit 63
+ *
+ * Implementation:
+ * To save hardware area, we store only these 7 bits in a 24-entry ROM 
+ * (168 bits total vs 1536 bits for a full 64-bit ROM). The 64-bit output 
+ * is reconstructed by mapping these 7 bits to their respective positions 
+ * and tying the remaining 57 bits to logic 0.
+ *
+ * Source: https://chemejon.wordpress.com/2021/12/06/sha-3-explained-in-plain-english/
+ *
+ * Note: Generated using Gemini AI
+ */
+module rconst_lut (
+    input  logic [4:0]  rnd_idx, // 0 to 23
+    output logic [63:0] rc_out
+);
+
+    logic [6:0] rc_7bit;
+
+    // The 24x7-bit compressed ROM
+    always_comb begin
+        case (rnd_idx)
+            5'd00: rc_7bit = 7'h01; 
+            5'd01: rc_7bit = 7'h1A;
+            5'd02: rc_7bit = 7'h5E; 
+            5'd03: rc_7bit = 7'h70;
+            5'd04: rc_7bit = 7'h1F; 
+            5'd05: rc_7bit = 7'h21;
+            5'd06: rc_7bit = 7'h79; 
+            5'd07: rc_7bit = 7'h55;
+            5'd08: rc_7bit = 7'h0E; 
+            5'd09: rc_7bit = 7'h0C;
+            5'd10: rc_7bit = 7'h35; 
+            5'd11: rc_7bit = 7'h26;
+            5'd12: rc_7bit = 7'h3F; 
+            5'd13: rc_7bit = 7'h4F;
+            5'd14: rc_7bit = 7'h5D; 
+            5'd15: rc_7bit = 7'h53;
+            5'd16: rc_7bit = 7'h52; 
+            5'd17: rc_7bit = 7'h48;
+            5'd18: rc_7bit = 7'h16; 
+            5'd19: rc_7bit = 7'h66;
+            5'd20: rc_7bit = 7'h79; 
+            5'd21: rc_7bit = 7'h58;
+            5'd22: rc_7bit = 7'h21; 
+            5'd23: rc_7bit = 7'h74;
+            default: rc_7bit = 7'h00;
+        endcase
+    end
+
+    // Bit-mapping to the 64-bit word
+    // SHA-3 indices: 0, 1, 3, 7, 15, 31, 63
+    always_comb begin
+        rc_out = 64'b0; // Default all bits to 0
+        rc_out[0]  = rc_7bit[0];
+        rc_out[1]  = rc_7bit[1];
+        rc_out[3]  = rc_7bit[2];
+        rc_out[7]  = rc_7bit[3];
+        rc_out[15] = rc_7bit[4];
+        rc_out[31] = rc_7bit[5];
+        rc_out[63] = rc_7bit[6];
+    end
+
+endmodule

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,38 @@
+# Helper function to create a Verilator testbench executable
+# Usage: add_verilator_test(<test_name> <top_module> <rtl_files...>)
+#
+# Example:
+#   add_verilator_test(tb_my_module my_module ${RTL_DIR}/my_module.sv ${RTL_DIR}/helper.sv)
+#
+function(add_verilator_test TEST_NAME TOP_MODULE)
+    set(RTL_SOURCES ${ARGN})
+    
+    # Create executable from testbench C++ file
+    add_executable(${TEST_NAME} ${TEST_NAME}.cpp)
+    
+    # Verilate the SystemVerilog design
+    verilate(${TEST_NAME} 
+        SOURCES ${RTL_SOURCES}
+        TOP_MODULE ${TOP_MODULE}
+        VERILATOR_ARGS --timing
+    )
+    
+    # Register with CTest
+    add_test(NAME ${TEST_NAME} COMMAND ${TEST_NAME})
+    
+    # Set test properties (optional: add timeout, working directory, etc.)
+    set_tests_properties(${TEST_NAME} PROPERTIES
+        TIMEOUT 30
+        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+    )
+endfunction()
+
+# =============================================================================
+# Add your tests below - one line per test!
+# =============================================================================
+
+add_verilator_test(tb_rconst_lut rconst_lut ${RTL_DIR}/rconst_lut.sv)
+
+# To add more tests, just add lines like:
+# add_verilator_test(tb_keccak_round keccak_round ${RTL_DIR}/keccak_round.sv)
+# add_verilator_test(tb_theta theta ${RTL_DIR}/theta.sv ${RTL_DIR}/helper.sv)

--- a/tests/tb_rconst_lut.cpp
+++ b/tests/tb_rconst_lut.cpp
@@ -1,0 +1,57 @@
+#include <iostream>
+#include <vector>
+#include <iomanip>
+#include "Vrconst_lut.h"    
+#include "verilated.h"
+
+int main(int argc, char** argv) {
+    Verilated::commandArgs(argc, argv);
+    Vrconst_lut* top = new Vrconst_lut;
+
+    // The gold standard values from the Keccak team
+    uint64_t official_rc[24] = {
+        0x0000000000000001, 0x0000000000008082, 0x800000000000808A, 0x8000000080008000,
+        0x000000000000808B, 0x0000000080000001, 0x8000000080008081, 0x8000000000008009,
+        0x000000000000008A, 0x0000000000000088, 0x0000000080008009, 0x000000008000000A,
+        0x000000008000808B, 0x800000000000008B, 0x8000000000008089, 0x8000000000008003,
+        0x8000000000008002, 0x8000000000000080, 0x000000000000800A, 0x800000008000000A,
+        0x8000000080008081, 0x8000000000008080, 0x0000000080000001, 0x8000000080008008
+    };
+
+    bool pass = true;
+
+    std::cout << "Starting SHA-3 Round Constant LUT Verification..." << std::endl;
+    std::cout << "----------------------------------------------------" << std::endl;
+
+    for (int i = 0; i < 24; i++) {
+        // 1. Set the input
+        top->rnd_idx = i;
+
+        // 2. Evaluate the combinational logic
+        top->eval();
+
+        // 3. Check the output
+        uint64_t hardware_out = top->rc_out;
+        
+        if (hardware_out == official_rc[i]) {
+            std::cout << "[PASS] Round " << std::setw(2) << i 
+                      << ": 0x" << std::hex << std::setfill('0') << std::setw(16) << hardware_out 
+                      << std::dec << std::endl;
+        } else {
+            std::cout << "[FAIL] Round " << std::setw(2) << i 
+                      << ": Expected 0x" << std::hex << official_rc[i] 
+                      << " but got 0x" << hardware_out << std::dec << std::endl;
+            pass = false;
+        }
+    }
+
+    std::cout << "----------------------------------------------------" << std::endl;
+    if (pass) {
+        std::cout << "RESULT: ALL TESTS PASSED!" << std::endl;
+    } else {
+        std::cout << "RESULT: TEST FAILED!" << std::endl;
+    }
+
+    delete top;
+    return pass ? 0 : 1;
+}


### PR DESCRIPTION
Implement round constant generation using 7-bit compressed LUT (168 bits vs 1536 bits for full storage). See comments in `rtl/rconst_lut.sv`. I've included a Verilator testbench and basic scaffolding for us to easily add additional tests using Cmake, see file `BUILD.md`. 